### PR TITLE
Merge [Feature/add-documentation] into [master]

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -743,12 +743,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "dotenv"
-version = "0.15.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "77c90badedccf4105eca100756a0b1289e191f6fcbdadd3cee1d2f614f97da8f"
-
-[[package]]
 name = "either"
 version = "1.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2354,7 +2348,6 @@ dependencies = [
  "chrono",
  "datamodel",
  "derive_more",
- "dotenv",
  "futures",
  "graphql-parser",
  "itoa 0.4.8",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,6 @@ path = "lib.rs"
 
 [build-dependencies]
 prisma-codegen = { path = "./codegen" }
-dotenv = "0.15.0"
 
 [dependencies]
 # serialization

--- a/README.md
+++ b/README.md
@@ -14,8 +14,9 @@ folder should be siblings.
     prisma-client = { git = "https://github.com/polytope-labs/prisma-client-rs", branch = "master" }
     serde = { version = "1.0", features = ["serde_derive"] }
     ```
-3. Create a .env in your project root and add the following:
+3. Create the `.cargo/config.toml` in your project root and add the following:
    ```
-   PRISMA_SCHEMA={PATH_TO_SCHEMA_FILE_HERE}
+   [env]
+   PRISMA_SCHEMA=ABSOLUTE/PATH/TO/SCHEMA/FILE/HERE
    ```
 4. Go through the example in the `example` folder to see how to use the client.   

--- a/build.rs
+++ b/build.rs
@@ -1,9 +1,6 @@
 use std::env;
-use dotenv::dotenv;
 
 fn main() {
-	dotenv().expect("Please setup the .env file as detailed in the README");
-
 	// get the prisma schema path from .env
 	let prisma_schema = env::var("PRISMA_SCHEMA")
 		.expect("Please set the enviroment variable to the absolute path of your prisma schema");


### PR DESCRIPTION
@seunlanlege Had to remove dotenv, and add documentation for using `.cargo/config.toml` to set the `PRISMA_SCHEMA` env variable instead.

Using dotenv and pulling in the library as a git dependency instead of using a path causes dotenv not to find the `.env` file because it looks for a `.env` file in the  `prisma-client-rs` cargo dependency directory instead of the main project directory.

I tried the following with no success:

- Using `dotenv:: from_filename` & `dotenv::from_path` to load the env file, but was unable to get the correct project path from with `build.rs` in the `prisma-client` library

I'll continue looking into this, as I figure there should be a cargo environement variable that provides the project path, however I'm making this PR as a stop-gap measure. 